### PR TITLE
Changed from module.export to export default to support PouchDB 6.3.4

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,37 @@
+// Type definitions for pouchdb-adapter-cordova-sqlite
+// TODO: JUST COPIED FROM pouchdb-adapter-websql! Please change to fit the correct plugin implementation!!!
+
+/// <reference types="pouchdb-core" />
+
+// TODO: Fixing this lint error will require a large refactor
+/* tslint:disable:no-single-declare-module */
+
+declare namespace PouchDB {
+    namespace Core {
+        interface DatabaseInfo {
+            sqlite_plugin?: boolean;
+            websql_encoding?: 'UTF-8' | 'UTF-16';
+        }
+    }
+
+    namespace AdapterCordovaSqlite {
+        interface Configuration
+                extends Configuration.LocalDatabaseConfiguration {
+            /**
+             * Amount in MB to request for storage.
+             */
+            size?: number;
+            adapter: 'cordova-sqlite';
+        }
+    }
+
+    interface Static {
+        new<Content extends {}>(name: string | null,
+                                options: AdapterCordovaSqlite.Configuration): Database<Content>;
+    }
+}
+
+declare module 'pouchdb-adapter-cordova-sqlite' {
+    const plugin: PouchDB.Plugin;
+    export = plugin;
+}

--- a/lib/assign.js
+++ b/lib/assign.js
@@ -1,26 +1,26 @@
-var assign
+var assign;
 if (typeof Object.assign === 'function') {
-  assign = Object.assign
+  assign = Object.assign;
 } else {
   // lite Object.assign polyfill based on
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
   assign = function (target) {
-    var to = Object(target)
+    var to = Object(target);
 
     for (var index = 1; index < arguments.length; index++) {
-      var nextSource = arguments[index]
+      var nextSource = arguments[index];
 
       if (nextSource != null) { // Skip over if undefined or null
         for (var nextKey in nextSource) {
           // Avoid bugs when hasOwnProperty is shadowed
           if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
-            to[nextKey] = nextSource[nextKey]
+            to[nextKey] = nextSource[nextKey];
           }
         }
       }
     }
-    return to
+    return to;
   }
 }
 
-module.exports = assign
+export default assign;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
-'use strict'
+'use strict';
 
-var WebSqlPouchCore = require('pouchdb-adapter-websql-core')
-var assign = require('./assign')
+import WebSqlPouchCore from 'pouchdb-adapter-websql-core';
+import assign from'./assign';
 
 /* global cordova, sqlitePlugin, openDatabase */
 function createOpenDBFunction (opts) {
@@ -17,20 +17,20 @@ function createOpenDBFunction (opts) {
         version: version,
         description: description,
         size: size
-      })
-      return sqlitePlugin.openDatabase(sqlitePluginOpts)
+      });
+      return sqlitePlugin.openDatabase(sqlitePluginOpts);
     }
 
     // Traditional WebSQL API
-    return openDatabase(name, version, description, size)
+    return openDatabase(name, version, description, size);
   }
 }
 
 function CordovaSQLitePouch (opts, callback) {
-  var websql = createOpenDBFunction(opts)
+  var websql = createOpenDBFunction(opts);
   var _opts = assign({
     websql: websql
-  }, opts)
+  }, opts);
 
   if (typeof cordova === 'undefined' || typeof sqlitePlugin === 'undefined' || typeof openDatabase === 'undefined') {
     console.error(
@@ -38,26 +38,26 @@ function CordovaSQLitePouch (opts, callback) {
       'in order for PouchDB to work on this platform. Options:' +
       '\n - https://github.com/nolanlawson/cordova-plugin-sqlite-2' +
       '\n - https://github.com/litehelpers/Cordova-sqlite-storage' +
-      '\n - https://github.com/Microsoft/cordova-plugin-websql')
+      '\n - https://github.com/Microsoft/cordova-plugin-websql');
   }
 
-  WebSqlPouchCore.call(this, _opts, callback)
+  WebSqlPouchCore.call(this, _opts, callback);
 }
 
 CordovaSQLitePouch.valid = function () {
   // if you're using Cordova, we assume you know what you're doing because you control the environment
-  return true
+  return true;
 }
 
 // no need for a prefix in cordova (i.e. no need for `_pouch_` prefix
-CordovaSQLitePouch.use_prefix = false
+CordovaSQLitePouch.use_prefix = false;
 
 function cordovaSqlitePlugin (PouchDB) {
-  PouchDB.adapter('cordova-sqlite', CordovaSQLitePouch, true)
+  PouchDB.adapter('cordova-sqlite', CordovaSQLitePouch, true);
 }
 
 if (typeof window !== 'undefined' && window.PouchDB) {
-  window.PouchDB.plugin(cordovaSqlitePlugin)
+  window.PouchDB.plugin(cordovaSqlitePlugin);
 }
 
-module.exports = cordovaSqlitePlugin
+export default cordovaSqlitePlugin;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "pouchdb-adapter-websql-core": "^6.1.1"
   },
   "devDependencies": {
+    "@types/pouchdb": "^6.3.0",
     "browserify": "^14.0.0",
     "bundle-collapser": "^1.2.1",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
Hi,

i am using this adapter within an Ionic 2 / Cordova application.
PouchDB 6.2.0 was working but after updating to 6.3.4 there are errors with this plugin (like undefined function call, etc...) because of problems with webpack and the export mechnism used.
I looked into the implementation in other adapters bundled with PouchDB and noticed a change in export mechanism.
So i changed the ```module.exports = ...``` to ```export default ...``` and this seems to work.
To work within Ionic (and possibly other angular or typescript based projects) i needed to add e typescript definition file also. I just copied the one from pouchdb-adapter-websql within `@types/pouchdb`, so you should look at it and make it fit this plugin if needed. (perhaps creating a standalone ```@types/pouchdb-adapter-cordova-sqlite``` package is a better way?)

would be great to see this adapter as a part of the pouchdb project..

p.s.: could not resist in adding semicolons ;-)
