### PR TITLE
Bug with cordova

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,7 +41,11 @@ function CordovaSQLitePouch (opts, callback) {
       '\n - https://github.com/Microsoft/cordova-plugin-websql')
   }
 
-  WebSqlPouchCore.call(this, _opts, callback)
+  if ( 'default' in WebSqlPouchCore && typeof WebSqlPouchCore.default.call === 'function') {
+    WebSqlPouchCore.default.call(this, _opts, callback)
+  } else {
+    WebSqlPouchCore.call(this, _opts, callback)
+  }
 }
 
 CordovaSQLitePouch.valid = function () {


### PR DESCRIPTION
WebSqlPouchCore.call is undefined, it stays in WebSqlPouchCore.default.call instead.

This patch correct the problem on my setup, still allows other (older) setup to work.