### PR TITLE
FIX - WebSqlPouchCore is not a function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var WebSqlPouchCore = require('pouchdb-adapter-websql-core')
+var WebSqlPouchCore = require('pouchdb-adapter-websql-core').default
 var assign = require('./assign')
 
 /* global cordova, sqlitePlugin, openDatabase */


### PR DESCRIPTION
Corrects the pouchdb-adapter-websql-core import to adapt to es6 module export format #78 