### PR TITLE
fix: change condition to show you must install a SQLite plugin error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ function CordovaSQLitePouch (opts, callback) {
     websql: websql
   }, opts)
 
-  if (typeof cordova === 'undefined' || typeof sqlitePlugin === 'undefined' || typeof openDatabase === 'undefined') {
+  if (typeof cordova === 'undefined' || (typeof sqlitePlugin === 'undefined' && typeof openDatabase === 'undefined')) {
     console.error(
       'PouchDB error: you must install a SQLite plugin ' +
       'in order for PouchDB to work on this platform. Options:' +


### PR DESCRIPTION
Trying to fix this issue: https://github.com/pouchdb-community/pouchdb-adapter-cordova-sqlite/issues/75

The plugin works but it is showing the false error of:
you must install a SQLite plugin in order for PouchDB to work on this platform.

I think this condition should be changed. I have been using this plugin for a client and they get concerned when seeing it throws that error everytime a db is opened.