### PR TITLE
Add support for capacitor check along with cordova in initialization

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ function CordovaSQLitePouch (opts, callback) {
     websql: websql
   }, opts)
 
-  if (typeof cordova === 'undefined' || (typeof sqlitePlugin === 'undefined' && typeof openDatabase === 'undefined')) {
+  if ((typeof Capacitor === 'undefined' && typeof cordova === 'undefined') || (typeof sqlitePlugin === 'undefined' && typeof openDatabase === 'undefined')) {
     console.error(
       'PouchDB error: you must install a SQLite plugin ' +
       'in order for PouchDB to work on this platform. Options:' +


### PR DESCRIPTION
An error message appears in the console when using Capacitor:

<img width="412" alt="Screen Shot 2021-02-15 at 12 21 08 PM" src="https://user-images.githubusercontent.com/44545113/107934100-4d6a9c80-6f88-11eb-98dc-19691b3af4ed.png">

Despite the fact that everything is working fine, this pull request adds the additional check for Capacitor along with the existing check of Cordova to remove the error showing in the console.